### PR TITLE
Use isolated Lua script for brick-and-mortar

### DIFF
--- a/db/uuid-vs-integer.md
+++ b/db/uuid-vs-integer.md
@@ -12,10 +12,10 @@ very important, focusing on them exclusively means that there are some critical
 points left out from the overall discussion of application performance and
 query efficiency.
 
-This article aims to provider the most thorough comparison of UUID and integer
-field performance. We'll be examining schemas that represent real-world
-application scenarios and run a series of comparative benchmarks that
-demonstrate the impact of using one strategy over another.
+This article aims to provide a thorough comparison of UUID and integer field
+performance. We'll be examining schemas that represent real-world application
+scenarios and run a series of comparative benchmarks that demonstrate the
+impact of using one strategy over another.
 
 1. [Overview](#overview)
 1. [Application database schemas](#application-databases)

--- a/db/uuid-vs-integer/schemas/brick-and-mortar/a.mysql
+++ b/db/uuid-vs-integer/schemas/brick-and-mortar/a.mysql
@@ -1,8 +1,4 @@
-DROP SCHEMA IF EXISTS brick_mortar_a;
-
-CREATE SCHEMA brick_mortar_a;
-
-CREATE TABLE suppliers (
+CREATE TABLE IF NOT EXISTS suppliers (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     address TEXT NOT NULL,
@@ -13,7 +9,7 @@ CREATE TABLE suppliers (
     updated_on DATETIME NULL
 );
 
-CREATE TABLE products (
+CREATE TABLE IF NOT EXISTS products (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     description TEXT NULL,
@@ -21,7 +17,7 @@ CREATE TABLE products (
     updated_on DATETIME NULL
 );
 
-CREATE TABLE product_price_history (
+CREATE TABLE IF NOT EXISTS product_price_history (
     product_id INT NOT NULL,
     starting_on DATETIME NOT NULL,
     ending_on DATETIME NOT NULL,
@@ -29,7 +25,7 @@ CREATE TABLE product_price_history (
     PRIMARY KEY (product_id, starting_on, ending_on)
 );
 
-CREATE TABLE inventories (
+CREATE TABLE IF NOT EXISTS inventories (
     product_id INT NOT NULL,
     supplier_id INT NOT NULL,
     total INT NOT NULL,
@@ -37,7 +33,7 @@ CREATE TABLE inventories (
     INDEX ix_supplier_id (supplier_id)
 );
 
-CREATE TABLE customers (
+CREATE TABLE IF NOT EXISTS customers (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     address TEXT NOT NULL,
@@ -48,7 +44,7 @@ CREATE TABLE customers (
     updated_on DATETIME NULL
 );
 
-CREATE TABLE orders (
+CREATE TABLE IF NOT EXISTS orders (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     customer_id INT NOT NULL,
     status VARCHAR(20) NOT NULL,
@@ -57,7 +53,7 @@ CREATE TABLE orders (
     INDEX ix_customer_id (customer_id)
 );
 
-CREATE order_details (
+CREATE TABLE IF NOT EXISTS order_details (
     order_id INT NOT NULL,
     product_id INT NOT NULL,
     amount INT NOT NULL,

--- a/db/uuid-vs-integer/schemas/brick-and-mortar/b.mysql
+++ b/db/uuid-vs-integer/schemas/brick-and-mortar/b.mysql
@@ -1,8 +1,4 @@
-DROP SCHEMA IF EXISTS brick_mortar_b;
-
-CREATE SCHEMA brick_mortar_a;
-
-CREATE TABLE suppliers (
+CREATE TABLE IF NOT EXISTS suppliers (
     uuid VARCHAR(36) NOT NULL PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     address TEXT NOT NULL,
@@ -13,7 +9,7 @@ CREATE TABLE suppliers (
     updated_on DATETIME NULL
 );
 
-CREATE TABLE products (
+CREATE TABLE IF NOT EXISTS products (
     uuid VARCHAR(36) NOT NULL PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     description TEXT NULL,
@@ -21,7 +17,7 @@ CREATE TABLE products (
     updated_on DATETIME NULL
 );
 
-CREATE TABLE product_price_history (
+CREATE TABLE IF NOT EXISTS product_price_history (
     product_uuid VARCHAR(36) NOT NULL,
     starting_on DATETIME NOT NULL,
     ending_on DATETIME NOT NULL,
@@ -29,7 +25,7 @@ CREATE TABLE product_price_history (
     PRIMARY KEY (product_uuid, starting_on, ending_on)
 );
 
-CREATE TABLE inventories (
+CREATE TABLE IF NOT EXISTS inventories (
     product_uuid VARCHAR(36) NOT NULL,
     supplier_uuid VARCHAR(36) NOT NULL,
     total INT NOT NULL,
@@ -37,7 +33,7 @@ CREATE TABLE inventories (
     INDEX ix_supplier_uuid (supplier_uuid)
 );
 
-CREATE TABLE customers (
+CREATE TABLE IF NOT EXISTS customers (
     uuid VARCHAR(36) NOT NULL PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     address TEXT NOT NULL,
@@ -48,7 +44,7 @@ CREATE TABLE customers (
     updated_on DATETIME NULL
 );
 
-CREATE TABLE orders (
+CREATE TABLE IF NOT EXISTS orders (
     uuid VARCHAR(36) NOT NULL PRIMARY KEY,
     customer_uuid VARCHAR(26) NOT NULL,
     status VARCHAR(20) NOT NULL,
@@ -57,7 +53,7 @@ CREATE TABLE orders (
     INDEX ix_customer_uuid (customer_uuid)
 );
 
-CREATE order_details (
+CREATE TABLE IF NOT EXISTS order_details (
     order_uuid VARCHAR(36) NOT NULL,
     product_uuid VARCHAR(36) NOT NULL,
     amount INT NOT NULL,

--- a/db/uuid-vs-integer/schemas/brick-and-mortar/c.mysql
+++ b/db/uuid-vs-integer/schemas/brick-and-mortar/c.mysql
@@ -1,8 +1,4 @@
-DROP SCHEMA IF EXISTS brick_mortar_c;
-
-CREATE SCHEMA brick_mortar_c;
-
-CREATE TABLE suppliers (
+CREATE TABLE IF NOT EXISTS suppliers (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     uuid VARCHAR(36) NOT NULL,
     name VARCHAR(200) NOT NULL,
@@ -15,7 +11,7 @@ CREATE TABLE suppliers (
     INDEX ix_uuid (uuid)
 );
 
-CREATE TABLE products (
+CREATE TABLE IF NOT EXISTS products (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     uuid VARCHAR(36) NOT NULL,
     name VARCHAR(200) NOT NULL,
@@ -25,7 +21,7 @@ CREATE TABLE products (
     INDEX ix_uuid (uuid)
 );
 
-CREATE TABLE product_price_history (
+CREATE TABLE IF NOT EXISTS product_price_history (
     product_id INT NOT NULL,
     starting_on DATETIME NOT NULL,
     ending_on DATETIME NOT NULL,
@@ -33,7 +29,7 @@ CREATE TABLE product_price_history (
     PRIMARY KEY (product_id, starting_on, ending_on)
 );
 
-CREATE TABLE inventories (
+CREATE TABLE IF NOT EXISTS inventories (
     product_id INT NOT NULL,
     supplier_id INT NOT NULL,
     total INT NOT NULL,
@@ -41,7 +37,7 @@ CREATE TABLE inventories (
     INDEX ix_supplier_id (supplier_id)
 );
 
-CREATE TABLE customers (
+CREATE TABLE IF NOT EXISTS customers (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     uuid VARCHAR(36) NOT NULL,
     name VARCHAR(200) NOT NULL,
@@ -54,7 +50,7 @@ CREATE TABLE customers (
     INDEX ix_uuid (uuid)
 );
 
-CREATE TABLE orders (
+CREATE TABLE IF NOT EXISTS orders (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     customer_id INT NOT NULL,
     uuid VARCHAR(36) NOT NULL,
@@ -65,7 +61,7 @@ CREATE TABLE orders (
     INDEX ix_uuid (uuid)
 );
 
-CREATE order_details (
+CREATE TABLE IF NOT EXISTS order_details (
     order_id INT NOT NULL,
     product_id INT NOT NULL,
     amount INT NOT NULL,


### PR DESCRIPTION
Since there will be a number of CLI parameters for the brick-and-mortar
Lua benchmarking script that won't be relevant to the employee-directory
benchmarks, make the bench.lua into brick-and-mortar.lua and remove the
application CLI option.

Also corrects some problems in the schema files and adds creation of the
schema and cleanup of the schema to the Lua script.

Issue #4